### PR TITLE
Refactor:

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,33 @@ Display the breadcrumbs. Example of usage:
   </nav>
 {{/breadcrumbs}}
 ```
+
+
+### Sidebar
+Display the sidebar. Example of usage:
+
+#### Helper
+The sidebar requires a helper so it can set the context in order to generate it. Also, it needs to build the sidebar recursively, so it requires a separate partial. Pass `level="0"` to add initial depth to the sidebar tree structure. Example:
+
+``` html
+{{#sidebar}}
+  {{> sidebar level="0"}}
+{{/sidebar}}
+```
+#### Partial
+Example of the recursive partial (`{{> sidebar}}`) for the sidebar
+
+``` html
+<ul class="sidebar-nav {{#if level}}sidebar-nav--level-{{level}}{{/if}}">
+  {{#each this as |item|}}
+    {{#if item}}
+      <li>
+        <a href="/{{item.section}}">{{item.title}}</a>
+        {{#if item.children}}
+          {{> sidebar item.children level=item.depth}}
+        {{/if}}
+      </li>
+    {{/if}}
+  {{/each}}
+</ul>
+```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Circus is a styleguide generator which processes YAML formatted comments in your
 Although, in many ways this project is very similar to [kss-node](https://github.com/kss-node/kss-node), it takes the "configuration over convention" approach to make the behaviour more explicit. Circus extracts YAML formatted comments from your source files, converts them into JSON objects and passes them into the Handlebars compiler to make the values available inside the templates. For example, given the following CSS file:
 ``` css
 /**
- * section: components.buttons
+ * section: components/buttons
  * title: Buttons
  *
  * description: |
@@ -18,7 +18,7 @@ Although, in many ways this project is very similar to [kss-node](https://github
  *
  * markup: sass/components/buttons/buttons
  */
- 
+
 .btn {
 }
 
@@ -28,7 +28,7 @@ Although, in many ways this project is very similar to [kss-node](https://github
 the following JSON object would be available to the template
 ``` javascript
 {
-  "section": "components.buttons",
+  "section": "components/buttons",
   "title": "Buttons",
   "description": "To create a button, simply add the following button classes to a `button`, `a`, or `input` element.\nEach button should have the `btn` class to start with, followed by the available button classes to create the desired button styling.\n",
   "modifiers": {
@@ -42,19 +42,21 @@ the following JSON object would be available to the template
 Currently, circus can only be used as a gulp plugin
 ``` javascript
   const circus = require('circus').default;
-  
+
   gulp.src('src/sass/**/*.scss'))
     .pipe(buffer())
     .pipe(circus({
        templates: {
-         index: 'src/styleguide/templates/index.hbs',
-         page: 'src/styleguide/templates/page.hbs',
+         homepage: path.join(opts.styleguideSource, '/templates/homepage.hbs'),
+         tableOfContents: path.join(opts.styleguideSource, '/templates/tableOfContents.hbs'),
+         leaf: path.join(opts.styleguideSource, '/templates/leaf.hbs'),
          partials: [
-           'src/styleguide/templates/partials/**/*.hbs',
-           'src/sass/**/*.hbs'
+           path.join(opts.styleguideSource, '/templates/partials/**/*.hbs'),
+           path.join('src/sass', '/**/*.hbs'),
+           path.join('src/fonts', '/**/*.hbs'),
          ]
        },
-       groupBy: block => block.section.replace(/\..*/, '')
+       groupBy: block => block.section.replace(/\//g, '/children/').split('/')
     }))
     .pipe('dist/');
 ```

--- a/README.md
+++ b/README.md
@@ -60,3 +60,22 @@ Currently, circus can only be used as a gulp plugin
     }))
     .pipe('dist/');
 ```
+
+## Partials and Helpers
+
+### Breadcrumbs
+Display the breadcrumbs. Example of usage:
+``` html
+{{#breadcrumbs section}}
+  <nav class="breadcrumbs">
+    {{#each this}}
+      {{#if @last}}
+        <span class="breadcrumbs__item breadcrumbs__item--last">{{label}}</span>
+      {{else}}
+        <a href="{{url}}" class="breadcrumbs__item">{{label}}</a>
+        <span class="breadcrumbs__separator"></span>
+      {{/if}}
+    {{/each}}
+  </nav>
+{{/breadcrumbs}}
+```

--- a/index.js
+++ b/index.js
@@ -15,8 +15,9 @@ module.exports = function circus({templates, groupBy, debug = false}) {
     yamlToJson(),
     aggregate(groupBy),
     handlebars({
-      index: templates.index,
-      page: templates.page,
+      homepage: templates.homepage,
+      tableOfContents: templates.tableOfContents,
+      leaf: templates.leaf,
       partials: templates.partials,
       debug
     }),

--- a/lib/streamTransformers/handlebars.js
+++ b/lib/streamTransformers/handlebars.js
@@ -67,30 +67,6 @@ function breadcrumbsToArray(path, sections) {
 }
 
 
-function breadcrumbsTemplate(path, sections) {
-
-  const breadcrumbItems = breadcrumbsToArray(path, sections);
-  const breadcrumbItemsLength = breadcrumbItems.length;
-
-  let html = '';
-
-
-  if(breadcrumbItems.length > 1) {
-    for(let i = 0; i < breadcrumbItemsLength; i++) {
-      if(i == breadcrumbItemsLength - 1) {
-        html += `<span class="breadcrumbs__item breadcrumbs__item--last">${breadcrumbItems[i].label}</span>`;
-      } else {
-        html += `<a href="/${breadcrumbItems[i].path}" class="breadcrumbs__item">${breadcrumbItems[i].label}</a><span class="breadcrumbs__separator"></span>`;
-      }
-    }
-
-    html = `<nav class="breadcrumbs">${html}</nav>`;
-  }
-
-  return html;
-}
-
-
 function generateSidebar(sections, index = 0) {
   let html = '';
   _.forOwn(sections, function(section) {
@@ -128,8 +104,11 @@ module.exports = function createHandlebarsStream({homepage, leaf, tableOfContent
 
       Handlebars.registerPartial('sidebar', sidebarTemplate);
 
-      Handlebars.registerHelper('breadcrumbs', (path) =>
-        breadcrumbsTemplate(path, docsBySection)
+      Handlebars.registerHelper('breadcrumbs', (context, options) => {
+          const items = breadcrumbsToArray(context, docsBySection);
+
+          return options.fn(items);
+        }
       );
 
       try {

--- a/lib/streamTransformers/handlebars.js
+++ b/lib/streamTransformers/handlebars.js
@@ -4,9 +4,10 @@ const globAsync = require('glob').glob;
 const _ = require('lodash');
 const through = require('through2');
 const marked = require('marked');
+const fs = require('fs');
 
-const fs = promisify('fs');
 const resolveGlob = promisify(globAsync);
+
 
 Handlebars.registerHelper('markdown', function(text) {
   if(! text) {
@@ -15,6 +16,7 @@ Handlebars.registerHelper('markdown', function(text) {
 
   return new Handlebars.SafeString(marked(text));
 });
+
 
 Handlebars.registerHelper('escapePartial', function(partialName) {
   var partial = Handlebars.partials[partialName];
@@ -25,50 +27,161 @@ Handlebars.registerHelper('escapePartial', function(partialName) {
   return partial();
 });
 
-module.exports = function createHandlebarsStream({index, page, partials, debug = false}) {
-  const indexTemplate = fs.readFile(index, 'utf8')
-      .then(compileTemplate);
-  const pageTemplate = fs.readFile(page, 'utf8')
-      .then(compileTemplate);
+
+function breadcrumbsGetLabel(path, sections) {
+
+  const items = path.split('/');
+  const itemsLength = items.length;
+
+  let label = sections;
+
+  for(let i = 0; i < itemsLength; i++) {
+    if(i < itemsLength - 1 && label[items[i]].hasOwnProperty('children')) {
+      label = label[items[i]]['children'];
+    } else {
+      label = label[items[i]];
+    }
+  }
+
+  return label['title'];
+};
+
+
+function breadcrumbsToArray(path, sections) {
+  let result = [];
+
+  path.split('/')
+      .reduce((finalPath, el) => {
+        const composedPath = finalPath + el;
+        const breadcrumbLabel = breadcrumbsGetLabel(composedPath, sections);
+
+        result.push({
+            label: breadcrumbLabel,
+            path: composedPath + '/'
+          });
+
+        return composedPath + '/';
+      }, '');
+
+  return result;
+}
+
+
+function breadcrumbsTemplate(path, sections) {
+
+  const breadcrumbItems = breadcrumbsToArray(path, sections);
+  const breadcrumbItemsLength = breadcrumbItems.length;
+
+  let html = '';
+
+
+  if(breadcrumbItems.length > 1) {
+    for(let i = 0; i < breadcrumbItemsLength; i++) {
+      if(i == breadcrumbItemsLength - 1) {
+        html += `<span class="breadcrumbs__item breadcrumbs__item--last">${breadcrumbItems[i].label}</span>`;
+      } else {
+        html += `<a href="/${breadcrumbItems[i].path}" class="breadcrumbs__item">${breadcrumbItems[i].label}</a><span class="breadcrumbs__separator"></span>`;
+      }
+    }
+
+    html = `<nav class="breadcrumbs">${html}</nav>`;
+  }
+
+  return html;
+}
+
+
+function generateSidebar(sections, index = 0) {
+  let html = '';
+  _.forOwn(sections, function(section) {
+    let sectionHtml = `<a href="/${section.section}/">${section.title}</a>`;
+
+    if(section.hasOwnProperty('children')) {
+      sectionHtml += generateSidebar(section.children, (index + 1));
+    }
+
+    html += `<li>${sectionHtml}</li>`;
+  });
+
+  return `<ul class="sidebar-nav sidebar-nav--level-${index}">${html}</ul>`;
+}
+
+
+
+
+module.exports = function createHandlebarsStream({homepage, leaf, tableOfContents, partials, debug = false}) {
+  const homepageTemplate = compileTemplate(fs.readFileSync(homepage, 'utf8'));
+  const leafTemplate = compileTemplate(fs.readFileSync(leaf, 'utf8'));
+
+  const tableOfContentsTemplate = compileTemplate(fs.readFileSync(tableOfContents, 'utf8'));
+
   const partialsLoaded = registerGlobPartials(partials, debug);
 
   let docsBySection;
-
-  Handlebars.registerHelper('withAllSections', function(options) {
-    return options.fn(docsBySection);
-  });
 
   return through(
     function(chunk, encoding, next) {
       docsBySection = JSON.parse(chunk.toString());
       const push = this.push.bind(this); //eslint-disable-line no-invalid-this
 
-      partialsLoaded
-        .then(() => pageTemplate)
-        .then(compile => ({ compile, groups: _.toPairs(docsBySection)}))
-        .then(({ compile, groups }) =>
-          groups
-            .map(([ name, data ]) => ({ name, contents: compile(data) }))
-         )
-        .then(pages =>
-          pages
+      const sidebarTemplate = generateSidebar(docsBySection);
+
+      Handlebars.registerPartial('sidebar', sidebarTemplate);
+
+      Handlebars.registerHelper('breadcrumbs', (path) =>
+        breadcrumbsTemplate(path, docsBySection)
+      );
+
+      try {
+        partialsLoaded.then(() => {
+          generatePages(tableOfContentsTemplate, leafTemplate, docsBySection)
             .map(JSON.stringify)
-            .forEach(push)
-        )
-        .then(() => next())
-        .catch(e => next(e));
+            .forEach(push);
+          next();
+        })
+        .catch((e) => console.log(e));
+      } catch (e) {
+        next(e);
+      }
     },
     function(done) {
       const push = this.push.bind(this); //eslint-disable-line no-invalid-this
-      indexTemplate
-        .then(compile => ({ name: 'index', contents: compile(docsBySection) }))
-        .then(JSON.stringify)
-        .then(push)
-        .then(() => done())
-        .catch(e => done(e));
+
+      try {
+        push(JSON.stringify({
+          name: 'index',
+          contents: homepageTemplate()
+        }));
+        done();
+      } catch(e) {
+        done(e);
+      }
     }
   );
 };
+
+function generatePages(tableOfContentsTemplate, leafTemplate, sections) {
+  let result = [];
+
+  _.forOwn(sections, function(section) {
+    const path = section.section + '/index';
+    if(section.hasOwnProperty('children')) {
+      result.push({
+        name: path,
+        contents: tableOfContentsTemplate(section)
+      });
+      const children = generatePages(tableOfContentsTemplate, leafTemplate, section.children)
+      result = result.concat(children);
+    } else {
+      result.push({
+        name: path,
+        contents: leafTemplate(section)
+      });
+    }
+  });
+
+  return result;
+}
 
 function compileTemplate(template) {
   return Handlebars.compile(template, {preventIndent: true});
@@ -84,12 +197,13 @@ function registerGlobPartials(globs, debug = false) {
         .map(
           ({ path, contents }) => {
             if(debug) {
-              console.log(`Registering partilal: ${path}`);
+              console.log(`Registering partial: ${path}`);
             }
             return Handlebars.registerPartial(path, compileTemplate(contents))
           }
         )
-    );
+    )
+    .catch(e => console.log(e));
 }
 
 function loadPartials(globs) {
@@ -98,10 +212,12 @@ function loadPartials(globs) {
     .then(_.flatten)
     .then(paths =>
       Promise.all(
-        paths.map(path =>
-          fs.readFile(path, 'utf8')
-            .then(contents => ({path, contents}))
-        )
+        paths.map(path => {
+          return {
+            path,
+            contents: fs.readFileSync(path, 'utf8')
+          };
+        })
       )
     );
 }

--- a/lib/streamTransformers/handlebars.js
+++ b/lib/streamTransformers/handlebars.js
@@ -67,22 +67,21 @@ function breadcrumbsToArray(path, sections) {
 }
 
 
-function generateSidebar(sections, index = 0) {
-  let html = '';
-  _.forOwn(sections, function(section) {
-    let sectionHtml = `<a href="/${section.section}/">${section.title}</a>`;
+function depthIteration(obj, depth) {
+  if(depth === 1) {
+    obj.depth = depth;
+  }
 
-    if(section.hasOwnProperty('children')) {
-      sectionHtml += generateSidebar(section.children, (index + 1));
+  for(key in obj) {
+    obj[key].depth = depth;
+
+    if(obj[key].hasOwnProperty('children')) {
+      depthIteration(obj[key]['children'], depth + 1);
     }
+  }
 
-    html += `<li>${sectionHtml}</li>`;
-  });
-
-  return `<ul class="sidebar-nav sidebar-nav--level-${index}">${html}</ul>`;
+  return obj;
 }
-
-
 
 
 module.exports = function createHandlebarsStream({homepage, leaf, tableOfContents, partials, debug = false}) {
@@ -100,9 +99,11 @@ module.exports = function createHandlebarsStream({homepage, leaf, tableOfContent
       docsBySection = JSON.parse(chunk.toString());
       const push = this.push.bind(this); //eslint-disable-line no-invalid-this
 
-      const sidebarTemplate = generateSidebar(docsBySection);
+      Handlebars.registerHelper('sidebar', (options) => {
+        const docsBySectionWithDepth = depthIteration(docsBySection, 1);
 
-      Handlebars.registerPartial('sidebar', sidebarTemplate);
+        return options.fn(docsBySectionWithDepth);
+      });
 
       Handlebars.registerHelper('breadcrumbs', (context, options) => {
           const items = breadcrumbsToArray(context, docsBySection);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igoratron/circus",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- support pages for each level
- have leaves and nodes for different levels
- change from "." to "/" for the separators
- introduce the "children" object for nodes that have sub-levels
- add breadcrumbs
- generate sidebar

**tests are failing - will need to fix :(**

EDIT 1: good news / bad news - the tests were not broken by the PR. They were failing before :(