### PR TITLE
Move breadcrumb functionality outside of Circus

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,24 +63,6 @@ Currently, circus can only be used as a gulp plugin
 
 ## Partials and Helpers
 
-### Breadcrumbs
-Display the breadcrumbs. Example of usage:
-``` html
-{{#breadcrumbs section}}
-  <nav class="breadcrumbs">
-    {{#each this}}
-      {{#if @last}}
-        <span class="breadcrumbs__item breadcrumbs__item--last">{{label}}</span>
-      {{else}}
-        <a href="{{url}}" class="breadcrumbs__item">{{label}}</a>
-        <span class="breadcrumbs__separator"></span>
-      {{/if}}
-    {{/each}}
-  </nav>
-{{/breadcrumbs}}
-```
-
-
 ### Sidebar
 Display the sidebar. Example of usage:
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const handlebars = require('./lib/streamTransformers/handlebars');
 const toVinyl = require('./lib/streamTransformers/toVinyl');
 const yamlToJson = require('./lib/streamTransformers/yamlToJson');
 
-module.exports = function circus({templates, groupBy, debug = false}) {
+module.exports = function circus({ templates, groupBy, helpers, debug = false }) {
   return combine(
     fromVinyl(),
     cssToYaml(),
@@ -19,6 +19,7 @@ module.exports = function circus({templates, groupBy, debug = false}) {
       tableOfContents: templates.tableOfContents,
       leaf: templates.leaf,
       partials: templates.partials,
+      helpers,
       debug
     }),
     toVinyl()

--- a/lib/streamTransformers/handlebars.js
+++ b/lib/streamTransformers/handlebars.js
@@ -27,46 +27,6 @@ Handlebars.registerHelper('escapePartial', function(partialName) {
   return partial();
 });
 
-
-function breadcrumbsGetLabel(path, sections) {
-
-  const items = path.split('/');
-  const itemsLength = items.length;
-
-  let label = sections;
-
-  for(let i = 0; i < itemsLength; i++) {
-    if(i < itemsLength - 1 && label[items[i]].hasOwnProperty('children')) {
-      label = label[items[i]]['children'];
-    } else {
-      label = label[items[i]];
-    }
-  }
-
-  return label['title'];
-};
-
-
-function breadcrumbsToArray(path, sections) {
-  let result = [];
-
-  path.split('/')
-      .reduce((finalPath, el) => {
-        const composedPath = finalPath + el;
-        const breadcrumbLabel = breadcrumbsGetLabel(composedPath, sections);
-
-        result.push({
-            label: breadcrumbLabel,
-            path: composedPath + '/'
-          });
-
-        return composedPath + '/';
-      }, '');
-
-  return result;
-}
-
-
 function depthIteration(obj, depth) {
   if(depth === 1) {
     obj.depth = depth;
@@ -84,7 +44,7 @@ function depthIteration(obj, depth) {
 }
 
 
-module.exports = function createHandlebarsStream({homepage, leaf, tableOfContents, partials, debug = false}) {
+module.exports = function createHandlebarsStream({ homepage, leaf, tableOfContents, partials, helpers, debug = false }) {
   const homepageTemplate = compileTemplate(fs.readFileSync(homepage, 'utf8'));
   const leafTemplate = compileTemplate(fs.readFileSync(leaf, 'utf8'));
 
@@ -104,13 +64,9 @@ module.exports = function createHandlebarsStream({homepage, leaf, tableOfContent
 
         return options.fn(docsBySectionWithDepth);
       });
-
-      Handlebars.registerHelper('breadcrumbs', (context, options) => {
-          const items = breadcrumbsToArray(context, docsBySection);
-
-          return options.fn(items);
-        }
-      );
+      
+      Object.entries(helpers)
+        .forEach(( [name, fn] ) => Handlebars.registerHelper(name, fn.bind(null, docsBySection)));
 
       try {
         partialsLoaded.then(() => {


### PR DESCRIPTION
- Remove `breadcrumb` functionality outside of circus
- Add the possibility of extending Circus with custom helpers in external projects that uses it.