### PR TITLE
Upgrade promisify-node to v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "js-yaml": "^3.4.2",
     "lodash": "^4.6.1",
     "marked": "^0.3.5",
-    "promisify-node": "^0.4.0",
+    "promisify-node": "^0.5.0",
     "stream-combiner": "^0.2.2",
     "through2": "^2.0.0"
   },


### PR DESCRIPTION
promisify-node v0.4.0 does not support node 10, this updates the version so that we can use it in applications that utilise node 10